### PR TITLE
Debug sync workflow issues

### DIFF
--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,7 +1,9 @@
 import workflow from "@convex-dev/workflow/convex.config";
+import crons from "@convex-dev/crons/convex.config";
 import { defineApp } from "convex/server";
 
 const app = defineApp();
 app.use(workflow);
+app.use(crons);
 
 export default app;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,14 +1,9 @@
 import { cronJobs } from "convex/server";
-import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-// Run the Stortinget sync workflow every day at 03:00 UTC.
-crons.cron(
-  "stortinget daily sync",
-  "0 3 * * *",
-  internal.sync.workflow.startWorkflow,
-  {},
-);
+// Static crons have been moved to runtime crons.
+// The nightly sync can now be toggled on/off via the sync settings page.
+// See convex/sync/settings.ts for the runtime cron management.
 
 export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -35,4 +35,9 @@ export default defineSchema({
       v.id("parties"),
     ), // Convex _id reference to avoid lookups
   }).index("by_table_and_external_id", ["table", "externalId"]),
+  // Sync settings for managing nightly sync toggle
+  syncSettings: defineTable({
+    key: v.string(), // Setting key (e.g., "nightly_sync_enabled")
+    enabled: v.boolean(), // Whether the setting is enabled
+  }).index("by_key", ["key"]),
 });

--- a/convex/sync/settings.ts
+++ b/convex/sync/settings.ts
@@ -1,0 +1,78 @@
+import { Crons } from "@convex-dev/crons";
+import { v } from "convex/values";
+import { components, internal } from "../_generated/api";
+import { mutation, query } from "../_generated/server";
+
+const crons = new Crons(components.crons);
+
+const NIGHTLY_SYNC_SETTING_KEY = "nightly_sync_enabled";
+const NIGHTLY_SYNC_CRON_NAME = "stortinget_daily_sync";
+
+/**
+ * Get the current nightly sync setting.
+ * Returns false by default if the setting doesn't exist.
+ */
+export const getNightlySyncEnabled = query({
+  args: {},
+  returns: v.boolean(),
+  handler: async (ctx) => {
+    const setting = await ctx.db
+      .query("syncSettings")
+      .withIndex("by_key", (q) => q.eq("key", NIGHTLY_SYNC_SETTING_KEY))
+      .unique();
+
+    return setting?.enabled ?? false;
+  },
+});
+
+/**
+ * Toggle the nightly sync setting and register/unregister the cron accordingly.
+ */
+export const toggleNightlySync = mutation({
+  args: {
+    enabled: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    // Update or create the setting
+    const existingSetting = await ctx.db
+      .query("syncSettings")
+      .withIndex("by_key", (q) => q.eq("key", NIGHTLY_SYNC_SETTING_KEY))
+      .unique();
+
+    if (existingSetting) {
+      await ctx.db.patch(existingSetting._id, { enabled: args.enabled });
+    } else {
+      await ctx.db.insert("syncSettings", {
+        key: NIGHTLY_SYNC_SETTING_KEY,
+        enabled: args.enabled,
+      });
+    }
+
+    // Register or unregister the cron based on the enabled state
+    if (args.enabled) {
+      // Check if cron already exists
+      const existingCron = await crons.get(ctx, { name: NIGHTLY_SYNC_CRON_NAME });
+
+      if (existingCron === null) {
+        // Register the cron to run every day at 03:00 UTC
+        await crons.register(
+          ctx,
+          { kind: "cron", cronspec: "0 3 * * *" },
+          internal.sync.workflow.startWorkflow,
+          {},
+          NIGHTLY_SYNC_CRON_NAME
+        );
+      }
+    } else {
+      // Unregister the cron if it exists
+      const existingCron = await crons.get(ctx, { name: NIGHTLY_SYNC_CRON_NAME });
+
+      if (existingCron !== null) {
+        await crons.delete(ctx, { name: NIGHTLY_SYNC_CRON_NAME });
+      }
+    }
+
+    return null;
+  },
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "knip": "knip"
   },
   "dependencies": {
+    "@convex-dev/crons": "^0.1.9",
     "@convex-dev/workflow": "0.2.7",
     "@convex-dev/workpool": "0.2.19",
     "@hookform/resolvers": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@convex-dev/crons':
+    specifier: ^0.1.9
+    version: 0.1.9(convex@1.28.0)
   '@convex-dev/workflow':
     specifier: 0.2.7
     version: 0.2.7(@convex-dev/workpool@0.2.19)(convex-helpers@0.1.104)(convex@1.28.0)
@@ -207,6 +210,15 @@ packages:
   /@babel/runtime@7.28.4:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@convex-dev/crons@0.1.9(convex@1.28.0):
+    resolution: {integrity: sha512-TV7hFli9iDekLQt95HgL1YfwdjG7TnVR2E+6meWo0VztdXqYN14aqwvEOcaadtDhFfedGx32xHZBFzvfgQZkYQ==}
+    peerDependencies:
+      convex: ~1.16.5 || >=1.17.0 <1.35.0
+    dependencies:
+      convex: 1.28.0(react@19.1.0)
+      cron-parser: 4.9.0
     dev: false
 
   /@convex-dev/workflow@0.2.7(@convex-dev/workpool@0.2.19)(convex-helpers@0.1.104)(convex@1.28.0):
@@ -3229,6 +3241,13 @@ packages:
       react: 19.1.0
     dev: false
 
+  /cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.7.2
+    dev: false
+
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -4670,6 +4689,11 @@ packages:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 19.1.0
+    dev: false
+
+  /luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
     dev: false
 
   /magic-string@0.30.18:


### PR DESCRIPTION
- Install @convex-dev/crons component for runtime cron management
- Add syncSettings table to store nightly sync enabled/disabled state
- Create sync/settings.ts with functions to manage nightly sync toggle
- Update sync page with toggle switch UI for enabling/disabling nightly sync
- Remove static cron from crons.ts (now managed at runtime)
- Nightly sync defaults to disabled and can be toggled per environment

This allows controlling the nightly sync independently on each environment without having crons run everywhere by default.