### PR TITLE
Add /parties route to list all political parties

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as crons from "../crons.js";
 import type * as stortinget_cases from "../stortinget/cases.js";
+import type * as stortinget_parties from "../stortinget/parties.js";
 import type * as sync_cases from "../sync/cases.js";
 import type * as sync_helpers from "../sync/helpers.js";
 import type * as sync_parties from "../sync/parties.js";
@@ -35,6 +36,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   crons: typeof crons;
   "stortinget/cases": typeof stortinget_cases;
+  "stortinget/parties": typeof stortinget_parties;
   "sync/cases": typeof sync_cases;
   "sync/helpers": typeof sync_helpers;
   "sync/parties": typeof sync_parties;

--- a/convex/stortinget/parties.ts
+++ b/convex/stortinget/parties.ts
@@ -1,0 +1,20 @@
+import { v } from "convex/values";
+import { query } from "../_generated/server";
+import { partyValidator } from "../sync/validators";
+
+export const listParties = query({
+  args: {},
+  returns: v.array(partyValidator),
+  handler: async (ctx) => {
+    const parties = await ctx.db.query("parties").collect();
+
+    // Sort parties by name
+    const sortedParties = parties.sort((a, b) => a.navn.localeCompare(b.navn));
+
+    return sortedParties.map((party) => ({
+      id: party.id,
+      navn: party.navn,
+      representert_parti: party.representert_parti,
+    }));
+  },
+});

--- a/src/app/parties/page.tsx
+++ b/src/app/parties/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import AsciiSpinner from "../ascii-spinner";
+
+export default function PartiesPage() {
+  const parties = useQuery(api.stortinget.parties.listParties);
+
+  if (parties === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <AsciiSpinner />
+      </div>
+    );
+  }
+
+  if (parties.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Ingen partier funnet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">Partier</h1>
+          <p className="text-muted-foreground">
+            Oversikt over politiske partier på Stortinget
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {parties.map((party) => (
+            <Card key={party.id} className="hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <CardTitle className="text-xl">{party.navn}</CardTitle>
+                <CardDescription className="text-sm">
+                  Parti-ID: {party.id}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  <Badge
+                    variant={party.representert_parti ? "default" : "secondary"}
+                  >
+                    {party.representert_parti
+                      ? "Representert"
+                      : "Ikke representert"}
+                  </Badge>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Create Convex query in convex/stortinget/parties.ts to fetch all parties
- Add Next.js page at /parties with card-based grid layout
- Display party name, ID, and representation status
- Follow existing design patterns (Card, Badge components)
- Sort parties alphabetically by name