### PR TITLE
Check and verify Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "eslint": "^9",
     "eslint-config-next": "^15.5.2",
     "knip": "^5.63.0",
-    "patch-package": "^8.0.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -74,11 +74,17 @@
     "eslint": "^9",
     "eslint-config-next": "^15.5.2",
     "knip": "^5.63.0",
+    "patch-package": "^8.0.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.2"
   },
-  "packageManager": "pnpm@8.15.6+sha512.77b89e9be77a2b06ad8f403a19cae5e22976f61023f98ad323d5c30194958ebc02ee0a6ae5d13ee454f6134e4e8caf29a05f0b1a0e1d2b17bca6b6a1f1159f86"
+  "packageManager": "pnpm@8.15.6+sha512.77b89e9be77a2b06ad8f403a19cae5e22976f61023f98ad323d5c30194958ebc02ee0a6ae5d13ee454f6134e4e8caf29a05f0b1a0e1d2b17bca6b6a1f1159f86",
+  "pnpm": {
+    "patchedDependencies": {
+      "convex@1.28.2": "patches/convex@1.28.2.patch"
+    }
+  }
 }

--- a/patches/convex@1.28.2.patch
+++ b/patches/convex@1.28.2.patch
@@ -1,0 +1,43 @@
+diff --git a/dist/cli.bundle.cjs b/dist/cli.bundle.cjs
+index 79420b40b92051641045963889aed52057afc8df..6197c53e024b163f45eece7876232a3c6cb39a11 100644
+--- a/dist/cli.bundle.cjs
++++ b/dist/cli.bundle.cjs
+@@ -184926,7 +184926,37 @@ async function main2() {
+   const minorVersion = parseInt(nodeVersion.split(".")[1], 10);
+   const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+   if (proxy) {
+-    (0, import_undici.setGlobalDispatcher)(new import_undici.ProxyAgent(proxy));
++    // PATCHED: Create ProxyAgent with proper NO_PROXY handling for localhost
++    const noProxy = (process.env.NO_PROXY || process.env.no_proxy || '').split(',').map(s => s.trim());
++    const shouldProxyLocalhost = !noProxy.some(ex => 
++      ex === 'localhost' || ex === '127.0.0.1' || ex === '::1' || ex === '0.0.0.0'
++    );
++    
++    if (shouldProxyLocalhost) {
++      (0, import_undici.setGlobalDispatcher)(new import_undici.ProxyAgent(proxy));
++    } else {
++      // Create a custom dispatcher that bypasses proxy for localhost
++      const originalDispatcher = (0, import_undici.getGlobalDispatcher)();
++      const proxyAgent = new import_undici.ProxyAgent(proxy);
++      
++      (0, import_undici.setGlobalDispatcher)({
++        dispatch(opts, handler) {
++          const url = opts.origin;
++          const isLocalhost = url && (
++            url.includes('://localhost') || 
++            url.includes('://127.0.0.1') ||
++            url.includes('://[::1]') ||
++            url.includes('://0.0.0.0')
++          );
++          
++          if (isLocalhost) {
++            return originalDispatcher.dispatch(opts, handler);
++          } else {
++            return proxyAgent.dispatch(opts, handler);
++          }
++        }
++      });
++    }
+     logVerbose(`[proxy-bootstrap] Using proxy: ${proxy}`);
+   }
+   import_node_dns.default.setDefaultResultOrder("ipv4first");

--- a/patches/convex@1.28.2.patch
+++ b/patches/convex@1.28.2.patch
@@ -1,36 +1,83 @@
 diff --git a/dist/cli.bundle.cjs b/dist/cli.bundle.cjs
-index 79420b40b92051641045963889aed52057afc8df..6197c53e024b163f45eece7876232a3c6cb39a11 100644
+index 79420b40b92051641045963889aed52057afc8df..d70778d35b9af0a6138ffb15ea64a6af1edf6f1e 100644
 --- a/dist/cli.bundle.cjs
 +++ b/dist/cli.bundle.cjs
-@@ -184926,7 +184926,37 @@ async function main2() {
+@@ -184926,8 +184926,84 @@ async function main2() {
    const minorVersion = parseInt(nodeVersion.split(".")[1], 10);
    const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
    if (proxy) {
 -    (0, import_undici.setGlobalDispatcher)(new import_undici.ProxyAgent(proxy));
-+    // PATCHED: Create ProxyAgent with proper NO_PROXY handling for localhost
-+    const noProxy = (process.env.NO_PROXY || process.env.no_proxy || '').split(',').map(s => s.trim());
-+    const shouldProxyLocalhost = !noProxy.some(ex => 
-+      ex === 'localhost' || ex === '127.0.0.1' || ex === '::1' || ex === '0.0.0.0'
-+    );
+-    logVerbose(`[proxy-bootstrap] Using proxy: ${proxy}`);
++    // PATCHED: Create ProxyAgent with proper NO_PROXY handling
++    // Parse NO_PROXY environment variable
++    const noProxyEnv = process.env.NO_PROXY || process.env.no_proxy || '';
++    const noProxyList = noProxyEnv.split(',').map(s => s.trim()).filter(Boolean);
 +    
-+    if (shouldProxyLocalhost) {
++    // Helper function to check if a URL should bypass the proxy
++    function shouldBypassProxy(urlString) {
++      if (!noProxyList.length) return false;
++      
++      try {
++        const url = new URL(urlString);
++        const hostname = url.hostname.toLowerCase();
++        
++        // Check against each NO_PROXY pattern
++        return noProxyList.some(pattern => {
++          const normalizedPattern = pattern.toLowerCase().trim();
++          
++          // Handle leading dot (e.g., .example.com matches sub.example.com)
++          if (normalizedPattern.startsWith('.')) {
++            return hostname.endsWith(normalizedPattern) || hostname === normalizedPattern.slice(1);
++          }
++          
++          // Handle wildcard subdomain (e.g., *.example.com)
++          if (normalizedPattern.startsWith('*.')) {
++            const domain = normalizedPattern.slice(2);
++            return hostname.endsWith('.' + domain) || hostname === domain;
++          }
++          
++          // Handle IP ranges (simple CIDR check for 127.0.0.0/8)
++          if (normalizedPattern.includes('/')) {
++            const [network, bits] = normalizedPattern.split('/');
++            if (network.startsWith('127.') && hostname.startsWith('127.')) {
++              return true; // Simplified: match all 127.x.x.x
++            }
++          }
++          
++          // Exact match or suffix match
++          return hostname === normalizedPattern || hostname.endsWith('.' + normalizedPattern);
++        });
++      } catch (e) {
++        // If URL parsing fails, don't bypass proxy
++        return false;
++      }
++    }
++    
++    // Check if localhost should be bypassed
++    const localhostPatterns = ['localhost', '127.0.0.1', '::1', '0.0.0.0', '.localhost', '127.0.0.0/8'];
++    const hasLocalhostBypass = noProxyList.some(pattern => {
++      const p = pattern.toLowerCase().trim();
++      return localhostPatterns.some(local => 
++        p === local || p === '.' + local || p.startsWith('127.') || p === '*'
++      );
++    });
++    
++    if (!hasLocalhostBypass) {
++      // No localhost bypass in NO_PROXY, use proxy normally
 +      (0, import_undici.setGlobalDispatcher)(new import_undici.ProxyAgent(proxy));
 +    } else {
-+      // Create a custom dispatcher that bypasses proxy for localhost
++      // Create a custom dispatcher that checks NO_PROXY per request
 +      const originalDispatcher = (0, import_undici.getGlobalDispatcher)();
 +      const proxyAgent = new import_undici.ProxyAgent(proxy);
 +      
 +      (0, import_undici.setGlobalDispatcher)({
 +        dispatch(opts, handler) {
-+          const url = opts.origin;
-+          const isLocalhost = url && (
-+            url.includes('://localhost') || 
-+            url.includes('://127.0.0.1') ||
-+            url.includes('://[::1]') ||
-+            url.includes('://0.0.0.0')
-+          );
++          // Check if this request should bypass proxy using proper URL parsing
++          const targetUrl = typeof opts.origin === 'string' 
++            ? opts.origin 
++            : opts.origin?.toString();
 +          
-+          if (isLocalhost) {
++          if (targetUrl && shouldBypassProxy(targetUrl)) {
 +            return originalDispatcher.dispatch(opts, handler);
 +          } else {
 +            return proxyAgent.dispatch(opts, handler);
@@ -38,6 +85,7 @@ index 79420b40b92051641045963889aed52057afc8df..6197c53e024b163f45eece7876232a3c
 +        }
 +      });
 +    }
-     logVerbose(`[proxy-bootstrap] Using proxy: ${proxy}`);
++    logVerbose(`[proxy-bootstrap] Using proxy: ${proxy}`)
    }
    import_node_dns.default.setDefaultResultOrder("ipv4first");
+   if (majorVersion >= 20) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   convex@1.28.2:
-    hash: 2dpame5zk5objwsvzdsvcztcxq
+    hash: duyz3nzyb7gpcdntqvugm6kday
     path: patches/convex@1.28.2.patch
 
 dependencies:
@@ -111,7 +111,7 @@ dependencies:
     version: 1.1.1(@types/react-dom@19.1.9)(@types/react@19.1.12)(react-dom@19.1.0)(react@19.1.0)
   convex:
     specifier: 1.28.2
-    version: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
+    version: 1.28.2(patch_hash=duyz3nzyb7gpcdntqvugm6kday)(react@19.1.0)
   date-fns:
     specifier: ^4.1.0
     version: 4.1.0
@@ -186,9 +186,6 @@ devDependencies:
   knip:
     specifier: ^5.63.0
     version: 5.63.0(@types/node@20.19.11)(typescript@5.9.2)
-  patch-package:
-    specifier: ^8.0.1
-    version: 8.0.1
   postcss:
     specifier: ^8.5.6
     version: 8.5.6
@@ -226,7 +223,7 @@ packages:
     dependencies:
       '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.104)(convex@1.28.2)
       async-channel: 0.2.0
-      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
+      convex: 1.28.2(patch_hash=duyz3nzyb7gpcdntqvugm6kday)(react@19.1.0)
       convex-helpers: 0.1.104(convex@1.28.2)(react@19.1.0)(typescript@5.9.2)(zod@4.1.12)
     dev: false
 
@@ -236,7 +233,7 @@ packages:
       convex: '>=1.25.0 <1.35.0'
       convex-helpers: ^0.1.94
     dependencies:
-      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
+      convex: 1.28.2(patch_hash=duyz3nzyb7gpcdntqvugm6kday)(react@19.1.0)
       convex-helpers: 0.1.104(convex@1.28.2)(react@19.1.0)(typescript@5.9.2)(zod@4.1.12)
     dev: false
 
@@ -2885,10 +2882,6 @@ packages:
     dev: true
     optional: true
 
-  /@yarnpkg/lockfile@1.1.0:
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-    dev: true
-
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3128,11 +3121,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-    dev: true
-
   /class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
     dependencies:
@@ -3219,13 +3207,13 @@ packages:
       zod:
         optional: true
     dependencies:
-      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
+      convex: 1.28.2(patch_hash=duyz3nzyb7gpcdntqvugm6kday)(react@19.1.0)
       react: 19.1.0
       typescript: 5.9.2
       zod: 4.1.12
     dev: false
 
-  /convex@1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0):
+  /convex@1.28.2(patch_hash=duyz3nzyb7gpcdntqvugm6kday)(react@19.1.0):
     resolution: {integrity: sha512-KzNsLbcVXb1OhpVQ+vHMgu+hjrsQ1ks5BZwJ2lR8O+nfbeJXE6tHbvsg1H17+ooUDvIDBSMT3vXS+AlodDhTnQ==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
@@ -4025,12 +4013,6 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-    dependencies:
-      micromatch: 4.0.8
-    dev: true
-
   /flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -4056,15 +4038,6 @@ packages:
     hasBin: true
     dependencies:
       fd-package-json: 2.0.0
-    dev: true
-
-  /fs-extra@10.1.0:
-    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
     dev: true
 
   /function-bind@1.1.2:
@@ -4336,12 +4309,6 @@ packages:
       has-tostringtag: 1.0.2
     dev: true
 
-  /is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dev: true
-
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -4460,13 +4427,6 @@ packages:
       get-intrinsic: 1.3.0
     dev: true
 
-  /is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-    dev: true
-
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
@@ -4514,34 +4474,11 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json-stable-stringify@1.3.0:
-    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-    dev: true
-
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
       minimist: 1.2.8
-    dev: true
-
-  /jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    dev: true
-
-  /jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -4558,12 +4495,6 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
-    dev: true
-
-  /klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
-    dependencies:
-      graceful-fs: 4.2.11
     dev: true
 
   /knip@5.63.0(@types/node@20.19.11)(typescript@5.9.2):
@@ -4943,14 +4874,6 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
-    dev: true
-
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -5018,27 +4941,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
-
-  /patch-package@8.0.1:
-    resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
-    engines: {node: '>=14', npm: '>5'}
-    hasBin: true
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      cross-spawn: 7.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 10.1.0
-      json-stable-stringify: 1.3.0
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      semver: 7.7.2
-      slash: 2.0.0
-      tmp: 0.2.5
-      yaml: 2.8.1
     dev: true
 
   /path-exists@4.0.0:
@@ -5505,11 +5407,6 @@ packages:
     dev: false
     optional: true
 
-  /slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
-    dev: true
-
   /smol-toml@1.4.2:
     resolution: {integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==}
     engines: {node: '>= 18'}
@@ -5689,11 +5586,6 @@ packages:
       picomatch: 4.0.3
     dev: true
 
-  /tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
-    engines: {node: '>=14.14'}
-    dev: true
-
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5795,11 +5687,6 @@ packages:
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-    dev: true
-
-  /universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
     dev: true
 
   /unrs-resolver@1.11.1:
@@ -5981,12 +5868,6 @@ packages:
   /yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
-    dev: true
-
-  /yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
     dev: true
 
   /yocto-queue@0.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  convex@1.28.2:
+    hash: 2dpame5zk5objwsvzdsvcztcxq
+    path: patches/convex@1.28.2.patch
+
 dependencies:
   '@convex-dev/workflow':
     specifier: 0.2.7
@@ -106,7 +111,7 @@ dependencies:
     version: 1.1.1(@types/react-dom@19.1.9)(@types/react@19.1.12)(react-dom@19.1.0)(react@19.1.0)
   convex:
     specifier: 1.28.2
-    version: 1.28.2(react@19.1.0)
+    version: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
   date-fns:
     specifier: ^4.1.0
     version: 4.1.0
@@ -181,6 +186,9 @@ devDependencies:
   knip:
     specifier: ^5.63.0
     version: 5.63.0(@types/node@20.19.11)(typescript@5.9.2)
+  patch-package:
+    specifier: ^8.0.1
+    version: 8.0.1
   postcss:
     specifier: ^8.5.6
     version: 8.5.6
@@ -218,7 +226,7 @@ packages:
     dependencies:
       '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.104)(convex@1.28.2)
       async-channel: 0.2.0
-      convex: 1.28.2(react@19.1.0)
+      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
       convex-helpers: 0.1.104(convex@1.28.2)(react@19.1.0)(typescript@5.9.2)(zod@4.1.12)
     dev: false
 
@@ -228,7 +236,7 @@ packages:
       convex: '>=1.25.0 <1.35.0'
       convex-helpers: ^0.1.94
     dependencies:
-      convex: 1.28.2(react@19.1.0)
+      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
       convex-helpers: 0.1.104(convex@1.28.2)(react@19.1.0)(typescript@5.9.2)(zod@4.1.12)
     dev: false
 
@@ -2877,6 +2885,10 @@ packages:
     dev: true
     optional: true
 
+  /@yarnpkg/lockfile@1.1.0:
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3116,6 +3128,11 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
+  /ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
     dependencies:
@@ -3202,13 +3219,13 @@ packages:
       zod:
         optional: true
     dependencies:
-      convex: 1.28.2(react@19.1.0)
+      convex: 1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0)
       react: 19.1.0
       typescript: 5.9.2
       zod: 4.1.12
     dev: false
 
-  /convex@1.28.2(react@19.1.0):
+  /convex@1.28.2(patch_hash=2dpame5zk5objwsvzdsvcztcxq)(react@19.1.0):
     resolution: {integrity: sha512-KzNsLbcVXb1OhpVQ+vHMgu+hjrsQ1ks5BZwJ2lR8O+nfbeJXE6tHbvsg1H17+ooUDvIDBSMT3vXS+AlodDhTnQ==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
@@ -3228,6 +3245,7 @@ packages:
       prettier: 3.6.2
       react: 19.1.0
     dev: false
+    patched: true
 
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4007,6 +4025,12 @@ packages:
       path-exists: 4.0.0
     dev: true
 
+  /find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
+    dependencies:
+      micromatch: 4.0.8
+    dev: true
+
   /flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -4032,6 +4056,15 @@ packages:
     hasBin: true
     dependencies:
       fd-package-json: 2.0.0
+    dev: true
+
+  /fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
     dev: true
 
   /function-bind@1.1.2:
@@ -4303,6 +4336,12 @@ packages:
       has-tostringtag: 1.0.2
     dev: true
 
+  /is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -4421,6 +4460,13 @@ packages:
       get-intrinsic: 1.3.0
     dev: true
 
+  /is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+    dev: true
+
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
@@ -4468,11 +4514,34 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+    dev: true
+
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
       minimist: 1.2.8
+    dev: true
+
+  /jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
+  /jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -4489,6 +4558,12 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
+
+  /klaw-sync@6.0.0:
+    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
+    dependencies:
+      graceful-fs: 4.2.11
     dev: true
 
   /knip@5.63.0(@types/node@20.19.11)(typescript@5.9.2):
@@ -4868,6 +4943,14 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
+  /open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: true
+
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4935,6 +5018,27 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /patch-package@8.0.1:
+    resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
+    engines: {node: '>=14', npm: '>5'}
+    hasBin: true
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      cross-spawn: 7.0.6
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 10.1.0
+      json-stable-stringify: 1.3.0
+      klaw-sync: 6.0.0
+      minimist: 1.2.8
+      open: 7.4.2
+      semver: 7.7.2
+      slash: 2.0.0
+      tmp: 0.2.5
+      yaml: 2.8.1
     dev: true
 
   /path-exists@4.0.0:
@@ -5401,6 +5505,11 @@ packages:
     dev: false
     optional: true
 
+  /slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
+    dev: true
+
   /smol-toml@1.4.2:
     resolution: {integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==}
     engines: {node: '>= 18'}
@@ -5580,6 +5689,11 @@ packages:
       picomatch: 4.0.3
     dev: true
 
+  /tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+    dev: true
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5681,6 +5795,11 @@ packages:
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    dev: true
+
+  /universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
     dev: true
 
   /unrs-resolver@1.11.1:
@@ -5862,6 +5981,12 @@ packages:
   /yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+    dev: true
+
+  /yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
     dev: true
 
   /yocto-queue@0.1.0:


### PR DESCRIPTION
This patch fixes a bug in the Convex CLI (v1.28.2) where local deployments would hang indefinitely in environments with HTTP proxies (like Claude Code on the web).

Root cause: The CLI uses undici's ProxyAgent without properly respecting NO_PROXY environment variables, causing localhost requests to go through the proxy and hang.

Solution: Create a custom dispatcher that:
- Checks NO_PROXY for localhost exclusions
- Bypasses proxy for localhost/127.0.0.1/::1/0.0.0.0
- Still uses proxy for all external requests

The patch is automatically applied during pnpm install via pnpm's built-in patching mechanism.

Files:
- patches/convex@1.28.2.patch: The patch file
- package.json: Added patchedDependencies field
- pnpm-lock.yaml: Updated with patch reference