### PR TITLE
Redesign header to match chat input style

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -18,13 +18,13 @@ export function AppHeader() {
           href="/"
           className="flex-1 bg-transparent px-3 py-2 group transition-colors"
         >
-          <h1 className="text-lg italic font-semibold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
+          <h1 className="text-sm font-normal tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
             Deep stortinget
           </h1>
         </Link>
         <button
           type="button"
-          className="flex-shrink-0 w-9 h-9 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
+          className="flex-shrink-0 w-9 h-9 rounded-full bg-muted text-muted-foreground hover:bg-muted/80 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
           aria-label="Menu"
         >
           <Menu className="w-4 h-4" />

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -18,13 +18,13 @@ export function AppHeader() {
           href="/"
           className="flex-1 bg-transparent px-3 py-2 group transition-colors"
         >
-          <h1 className="text-sm font-normal tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
+          <h1 className="text-sm font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
             Deep stortinget
           </h1>
         </Link>
         <button
           type="button"
-          className="flex-shrink-0 w-9 h-9 rounded-full bg-muted text-muted-foreground hover:bg-muted/80 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
+          className="flex-shrink-0 w-9 h-9 rounded-full bg-muted text-muted-foreground hover:bg-muted/80 transition-all duration-200 flex items-center justify-center"
           aria-label="Menu"
         >
           <Menu className="w-4 h-4" />

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -8,22 +8,20 @@ export function AppHeader() {
 
   return (
     <header
-      className={`fixed top-0 left-0 right-0 z-50 transition-transform duration-300 ease-in-out ${
+      className={`fixed top-0 left-0 right-0 z-50 flex justify-center p-3 transition-transform duration-300 ease-in-out ${
         isVisible ? "translate-y-0" : "-translate-y-full"
       }`}
     >
-      <div className="backdrop-blur-md bg-background/80 border-b border-border">
-        <div className="container mx-auto px-4 max-w-4xl">
-          <div className="flex items-center justify-between h-16">
-            <Link
-              href="/"
-              className="flex items-center gap-2 group transition-colors"
-            >
-              <h1 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
-                Deep stortinget
-              </h1>
-            </Link>
-          </div>
+      <div className="w-full max-w-2xl backdrop-blur-md bg-background/80 border border-border shadow-lg rounded-full px-6 py-3">
+        <div className="flex items-center justify-between">
+          <Link
+            href="/"
+            className="flex items-center gap-2 group transition-colors"
+          >
+            <h1 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
+              Deep stortinget
+            </h1>
+          </Link>
         </div>
       </div>
     </header>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { Menu } from "lucide-react";
 import { useScrollVisibility } from "@/hooks/use-scroll-visibility";
 
 export function AppHeader() {
@@ -13,15 +14,22 @@ export function AppHeader() {
       }`}
     >
       <div className="w-full max-w-2xl backdrop-blur-md bg-background/80 border border-border shadow-lg rounded-full px-6 py-3">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <Link
             href="/"
             className="flex items-center gap-2 group transition-colors"
           >
-            <h1 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
+            <h1 className="text-lg italic font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
               Deep stortinget
             </h1>
           </Link>
+          <button
+            type="button"
+            className="flex-shrink-0 w-9 h-9 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
+            aria-label="Menu"
+          >
+            <Menu className="w-4 h-4" />
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -13,24 +13,22 @@ export function AppHeader() {
         isVisible ? "translate-y-0" : "-translate-y-full"
       }`}
     >
-      <div className="w-full max-w-2xl backdrop-blur-md bg-background/80 border border-border shadow-lg rounded-full px-6 py-3">
-        <div className="flex items-center justify-between gap-2">
-          <Link
-            href="/"
-            className="flex items-center gap-2 group transition-colors"
-          >
-            <h1 className="text-lg italic font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
-              Deep stortinget
-            </h1>
-          </Link>
-          <button
-            type="button"
-            className="flex-shrink-0 w-9 h-9 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
-            aria-label="Menu"
-          >
-            <Menu className="w-4 h-4" />
-          </button>
-        </div>
+      <div className="w-full max-w-2xl backdrop-blur-md bg-background/80 border border-border shadow-lg flex items-center gap-2 p-2 transition-all duration-200 rounded-full">
+        <Link
+          href="/"
+          className="flex-1 bg-transparent px-3 py-2 group transition-colors"
+        >
+          <h1 className="text-lg italic font-semibold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent group-hover:from-primary group-hover:to-primary/70 transition-all duration-300">
+            Deep stortinget
+          </h1>
+        </Link>
+        <button
+          type="button"
+          className="flex-shrink-0 w-9 h-9 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 flex items-center justify-center shadow-md hover:shadow-lg"
+          aria-label="Menu"
+        >
+          <Menu className="w-4 h-4" />
+        </button>
       </div>
     </header>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -19,6 +19,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        muted: "bg-muted text-muted-foreground hover:bg-muted/80",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
Apply consistent visual design between header and chat input by:
- Using centered layout with max-w-2xl container
- Adding rounded-full border for pill-shaped appearance
- Including shadow-lg for depth
- Maintaining frosted glass backdrop effect
- Matching padding and spacing to chat input