### PR TITLE
Fix sync runs table sorting

### DIFF
--- a/src/app/sync/columns.tsx
+++ b/src/app/sync/columns.tsx
@@ -137,7 +137,18 @@ export const columns: ColumnDef<SyncRun>[] = [
   },
   {
     id: "added",
-    header: "Lagt til",
+    header: ({ column }) => {
+      return (
+        <button
+          className="flex items-center gap-1 hover:text-foreground"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Lagt til
+          {column.getIsSorted() === "asc" && <span>↑</span>}
+          {column.getIsSorted() === "desc" && <span>↓</span>}
+        </button>
+      );
+    },
     accessorFn: (row) => {
       const total =
         (row.partiesAdded ?? 0) +
@@ -161,7 +172,18 @@ export const columns: ColumnDef<SyncRun>[] = [
   },
   {
     id: "updated",
-    header: "Oppdatert",
+    header: ({ column }) => {
+      return (
+        <button
+          className="flex items-center gap-1 hover:text-foreground"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Oppdatert
+          {column.getIsSorted() === "asc" && <span>↑</span>}
+          {column.getIsSorted() === "desc" && <span>↓</span>}
+        </button>
+      );
+    },
     accessorFn: (row) => {
       const total =
         (row.partiesUpdated ?? 0) +
@@ -185,7 +207,18 @@ export const columns: ColumnDef<SyncRun>[] = [
   },
   {
     id: "skipped",
-    header: "Hoppet over",
+    header: ({ column }) => {
+      return (
+        <button
+          className="flex items-center gap-1 hover:text-foreground"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Hoppet over
+          {column.getIsSorted() === "asc" && <span>↑</span>}
+          {column.getIsSorted() === "desc" && <span>↓</span>}
+        </button>
+      );
+    },
     accessorFn: (row) => {
       const total =
         (row.partiesSkipped ?? 0) +

--- a/src/app/sync/data-table.tsx
+++ b/src/app/sync/data-table.tsx
@@ -3,7 +3,9 @@
 import {
   flexRender,
   getCoreRowModel,
+  getSortedRowModel,
   RowSelectionState,
+  SortingState,
   useReactTable,
 } from "@tanstack/react-table";
 import { useState } from "react";
@@ -49,6 +51,12 @@ export function DataTable() {
   };
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: "startedAt",
+      desc: true,
+    },
+  ]);
   const selectedIds = Object.keys(rowSelection) as Id<"syncRuns">[];
 
   // Handle delete selected runs
@@ -68,9 +76,12 @@ export function DataTable() {
     data: data ?? [],
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
     state: {
       rowSelection,
+      sorting,
     },
     enableRowSelection: true,
     getRowId: (row) => {


### PR DESCRIPTION
- Add sorting model and state with default sort by startedAt descending
- Add sortable headers to added, updated, and skipped columns
- Keep checkbox and details columns non-sortable
- All sortable columns now show up/down arrows indicating sort direction