### PR TITLE
Use authenticated WorkOS user data in sidebar nav profile

### DIFF
--- a/convex/README.md
+++ b/convex/README.md
@@ -1,0 +1,88 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) => console.log(result));
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,7 +1,7 @@
 {
   /* This TypeScript project config describes the environment that
    * Convex functions run in and is used to typecheck them.
-   * You can modify it, but some settings required to use Convex.
+   * You can modify it, but some settings are required to use Convex.
    */
   "compilerOptions": {
     /* These settings are not required by Convex and can be modified. */

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -24,11 +24,6 @@ import {
 import { AppNavThreads } from "~/features/threads/app-nav-threads";
 
 const data = {
-  user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
-  },
   navMain: [
     {
       title: "Playground",
@@ -153,7 +148,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        <NavUser />
       </SidebarFooter>
     </Sidebar>
   );

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,3 +1,5 @@
+import type { User } from "@workos/authkit-tanstack-react-start";
+
 import {
   IconSelector,
   IconSparkles,
@@ -6,6 +8,8 @@ import {
   IconBell,
   IconLogout,
 } from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
+import { useAuth } from "@workos/authkit-tanstack-react-start/client";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import {
@@ -24,16 +28,38 @@ import {
   useSidebar,
 } from "~/components/ui/sidebar";
 
-export function NavUser({
-  user,
-}: {
-  user: {
-    name: string;
-    email: string;
-    avatar: string;
-  };
-}) {
+function isNonEmptyString(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function getUserDisplayName(user: User) {
+  const fullName = [user.firstName, user.lastName].filter(isNonEmptyString).join(" ").trim();
+  return fullName || user.email;
+}
+
+function getUserInitials(user: User) {
+  const nameParts = [user.firstName, user.lastName].filter(isNonEmptyString);
+  if (nameParts.length > 0) {
+    return nameParts
+      .map((part) => part[0]?.toUpperCase() ?? "")
+      .join("")
+      .slice(0, 2);
+  }
+
+  return user.email.slice(0, 2).toUpperCase();
+}
+
+export function NavUser() {
   const { isMobile } = useSidebar();
+  const { user } = useAuth();
+
+  if (!user) {
+    return null;
+  }
+
+  const displayName = getUserDisplayName(user);
+  const initials = getUserInitials(user);
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
@@ -42,11 +68,11 @@ export function NavUser({
             render={<SidebarMenuButton size="lg" className="aria-expanded:bg-muted" />}
           >
             <Avatar>
-              <AvatarImage src={user.avatar} alt={user.name} />
-              <AvatarFallback>CN</AvatarFallback>
+              <AvatarImage src={user.profilePictureUrl ?? undefined} alt={displayName} />
+              <AvatarFallback>{initials}</AvatarFallback>
             </Avatar>
             <div className="grid flex-1 text-left text-sm leading-tight">
-              <span className="truncate font-medium">{user.name}</span>
+              <span className="truncate font-medium">{displayName}</span>
               <span className="truncate text-xs">{user.email}</span>
             </div>
             <IconSelector className="ml-auto size-4" />
@@ -61,11 +87,11 @@ export function NavUser({
               <DropdownMenuLabel className="p-0 font-normal">
                 <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                   <Avatar>
-                    <AvatarImage src={user.avatar} alt={user.name} />
-                    <AvatarFallback>CN</AvatarFallback>
+                    <AvatarImage src={user.profilePictureUrl ?? undefined} alt={displayName} />
+                    <AvatarFallback>{initials}</AvatarFallback>
                   </Avatar>
                   <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate font-medium">{user.name}</span>
+                    <span className="truncate font-medium">{displayName}</span>
                     <span className="truncate text-xs">{user.email}</span>
                   </div>
                 </div>
@@ -94,7 +120,7 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
+            <DropdownMenuItem render={<Link to="/logout" reloadDocument />}>
               <IconLogout />
               Log out
             </DropdownMenuItem>

--- a/src/features/threads/app-nav-threads.tsx
+++ b/src/features/threads/app-nav-threads.tsx
@@ -1,6 +1,6 @@
 import { convexQuery } from "@convex-dev/react-query";
 import { useConvexMutation } from "@convex-dev/react-query";
-import { IconDots, IconMessageCircle, IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
+import { IconDots, IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { FormEvent, useEffect, useState } from "react";


### PR DESCRIPTION
## Summary
- Replace hardcoded sidebar profile data with the authenticated WorkOS user from `useAuth()`.
- Update `NavUser` to derive display name and initials from WorkOS user fields, with email-based fallbacks.
- Wire avatar rendering to `profilePictureUrl` and keep profile info consistent in both trigger and dropdown.
- Change logout menu item to navigate via `Link` to `/logout` with document reload.
- Remove an unused icon import in thread navigation and add Convex starter README plus minor tsconfig comment fix.

## Testing
- Not run (no test or runtime verification output provided in this diff).
- Manual check recommended: sign in and confirm sidebar shows current WorkOS user name/email/avatar.
- Manual check recommended: verify initials fallback when profile picture or names are missing.
- Manual check recommended: click **Log out** and confirm it reaches `/logout` and signs the user out.